### PR TITLE
Fix installation when GOPATH not set

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,3 +1,4 @@
+GOPATH ?= $(HOME)/go
 TEST?=./...
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 PKG_NAME=xaptum

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -12,7 +12,7 @@ test: fmtcheck
 	go test $(TEST) -timeout=30s -parallel=4
 
 install: build
-	ln -s $(GOPATH)/bin/terraform-provider-xaptum $(HOME)/.terraform.d/plugins/terraform-provider-xaptum
+	ln -fs $(GOPATH)/bin/terraform-provider-xaptum $(HOME)/.terraform.d/plugins/terraform-provider-xaptum
 
 release: build
 	scripts/release.sh


### PR DESCRIPTION
The `make install` command referenced the `GOPATH` environment variable, so would fail if it was not set.

Go defaults to `$HOME/go` when `GOPATH` is not set, so use that same default in the Makefile.
